### PR TITLE
feat: mobile-responsive frontend layout

### DIFF
--- a/frontend-demo/src/components/analysis/SummaryView.tsx
+++ b/frontend-demo/src/components/analysis/SummaryView.tsx
@@ -80,7 +80,7 @@ export function SummaryView() {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-2xl font-bold text-foreground mb-2">
+        <h2 className="text-xl sm:text-2xl font-bold text-foreground mb-2">
           Drug Discovery Summary
         </h2>
         <p className="text-muted-foreground">
@@ -121,7 +121,7 @@ export function SummaryView() {
                   #{candidate.rank}
                 </span>
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
+                  <div className="flex flex-wrap items-center gap-2 mb-1">
                     <span className="font-semibold text-foreground">{candidate.name}</span>
                     <Badge variant={safetyVariants[candidate.safety]}>
                       {candidate.score}/100

--- a/frontend-demo/src/components/drug-candidates/CandidateCard.tsx
+++ b/frontend-demo/src/components/drug-candidates/CandidateCard.tsx
@@ -75,12 +75,12 @@ export function CandidateCard({ candidate, tier, compact, selected, onClick }: C
 
   return (
     <div
-      className={`flex items-center gap-4 px-4 py-3 rounded-lg border border-border transition-colors hover:bg-muted/40 ${onClick ? 'cursor-pointer' : ''} ${tierStyle?.row ?? ''}`}
+      className={`flex items-center gap-3 sm:gap-4 px-3 sm:px-4 py-3 rounded-lg border border-border transition-colors hover:bg-muted/40 ${onClick ? 'cursor-pointer' : ''} ${tierStyle?.row ?? ''}`}
       onClick={() => onClick?.(candidate)}
     >
-      <div className="w-12 shrink-0 text-center">
+      <div className="w-10 sm:w-12 shrink-0 text-center">
         {ranking?.score ? (
-          <span className={`text-lg font-bold font-mono ${tierStyle?.accent ?? 'text-muted-foreground'}`}>
+          <span className={`text-base sm:text-lg font-bold font-mono ${tierStyle?.accent ?? 'text-muted-foreground'}`}>
             {ranking.score}
           </span>
         ) : (
@@ -88,7 +88,7 @@ export function CandidateCard({ candidate, tier, compact, selected, onClick }: C
         )}
       </div>
 
-      <div className="w-52 shrink-0 min-w-0">
+      <div className="flex-1 min-w-0">
         <div className="font-semibold text-sm text-foreground truncate">
           {displayName}
           {tier === 'elite' && !omStatus && (
@@ -114,7 +114,7 @@ export function CandidateCard({ candidate, tier, compact, selected, onClick }: C
         <PropPill label="PSA" value={candidate.psa?.toFixed(0)} tooltip="Polar Surface Area in Å² — affects oral bioavailability and membrane transport" />
       </div>
 
-      <div className="flex items-center gap-1.5 shrink-0 ml-auto">
+      <div className="hidden sm:flex items-center gap-1.5 shrink-0 ml-auto">
         {omStatus && (
           <Badge variant="outline" className="text-xs border-violet-400 text-violet-600 dark:text-violet-400 dark:border-violet-500" title={omStatus}>
             Existing OM

--- a/frontend-demo/src/components/drug-candidates/DrugCandidatesView.tsx
+++ b/frontend-demo/src/components/drug-candidates/DrugCandidatesView.tsx
@@ -2,14 +2,17 @@ import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useDrugCandidates } from '@/hooks/use-drug-candidates';
 import { CandidateCard } from './CandidateCard';
 import { CandidateDetailPanel } from './CandidateDetailPanel';
+import { CandidateDetailDrawer } from './CandidateDetailDrawer';
 import { getCandidateTier, getCandidateScore, getExistingOmStatus } from '@/lib/candidate-tiers';
 import { useUrlParam, useUrlState } from '@/hooks/use-url-state';
+import { useIsMobile } from '@/hooks/use-media-query';
 import type { DrugCandidate } from '@/types/drug-candidate';
 
 export function DrugCandidatesView() {
   const { candidates, routeData, indicationFrequency, loading, error } = useDrugCandidates();
   const { update } = useUrlState();
   const drugParam = useUrlParam('drug');
+  const isMobile = useIsMobile();
   const [search, setSearch] = useState('');
   const [filterNatural, setFilterNatural] = useState(false);
   const [filterExistingOm, setFilterExistingOm] = useState(true);
@@ -77,46 +80,47 @@ export function DrugCandidatesView() {
   }
 
   const hasSelection = selectedCandidate !== null;
+  const showSplitPane = hasSelection && !isMobile;
 
   return (
-    <div className={hasSelection ? 'flex gap-0 -mx-4 sm:-mx-6' : ''}>
+    <div className={showSplitPane ? 'flex gap-0 -mx-4 sm:-mx-6' : ''}>
       {/* List panel */}
       <div
         className={
-          hasSelection
+          showSplitPane
             ? 'w-72 shrink-0 border-r border-border flex flex-col h-[calc(100vh-12rem)]'
             : ''
         }
       >
-        <div className={hasSelection ? 'px-3 pt-3 pb-2 space-y-2 shrink-0' : ''}>
+        <div className={showSplitPane ? 'px-3 pt-3 pb-2 space-y-2 shrink-0' : ''}>
           {/* Search */}
-          <div className={hasSelection ? '' : 'flex flex-col sm:flex-row gap-3 mb-6'}>
-            <div className={hasSelection ? '' : 'flex-1'}>
+          <div className={showSplitPane ? '' : 'flex flex-col sm:flex-row gap-3 mb-6'}>
+            <div className={showSplitPane ? '' : 'flex-1'}>
               <input
                 type="text"
-                placeholder={hasSelection ? 'Search...' : 'Search by name, ChemBL ID, or indication...'}
+                placeholder={showSplitPane ? 'Search...' : 'Search by name, ChemBL ID, or indication...'}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 className="w-full px-3 py-2 rounded-md border border-input bg-background text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
               />
             </div>
-            {!hasSelection && (
-              <div className="flex items-center gap-4 shrink-0">
-                <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
+            {!showSplitPane && (
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2 shrink-0">
+                <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer min-h-[44px]">
                   <input
                     type="checkbox"
                     checked={filterNatural}
                     onChange={(e) => setFilterNatural(e.target.checked)}
-                    className="rounded border-input"
+                    className="rounded border-input size-4"
                   />
                   <span title="Show only compounds derived from natural sources (plants, fungi, etc.)">Natural products only</span>
                 </label>
-                <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
+                <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer min-h-[44px]">
                   <input
                     type="checkbox"
                     checked={filterExistingOm}
                     onChange={(e) => setFilterExistingOm(e.target.checked)}
-                    className="rounded border-input"
+                    className="rounded border-input size-4"
                   />
                   <span title="Hide existing drugs for Oral Mucositis">Hide existing OM drugs</span>
                 </label>
@@ -125,7 +129,7 @@ export function DrugCandidatesView() {
           </div>
 
           {/* Legend + count */}
-          {!hasSelection && (
+          {!showSplitPane && (
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground mb-4">
               <span>Showing {filtered.length} of {candidates.length} candidates</span>
               <span className="flex items-center gap-1.5" title="Top-scoring candidates (score >= 55) — strongest evidence for OM treatment">
@@ -144,7 +148,7 @@ export function DrugCandidatesView() {
             </div>
           )}
 
-          {hasSelection && (
+          {showSplitPane && (
             <div className="space-y-1.5">
               <div className="flex flex-col gap-1">
                 <label className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer">
@@ -176,7 +180,7 @@ export function DrugCandidatesView() {
         {/* Candidate list */}
         <div
           className={
-            hasSelection
+            showSplitPane
               ? 'flex-1 overflow-y-auto px-2 pb-2 space-y-0.5'
               : 'flex flex-col gap-1.5'
           }
@@ -186,8 +190,8 @@ export function DrugCandidatesView() {
               key={candidate.chembl_id || candidate.drug_name}
               candidate={candidate}
               tier={getCandidateTier(candidate.chembl_id)}
-              compact={hasSelection}
-              selected={hasSelection && selectedCandidate?.chembl_id === candidate.chembl_id}
+              compact={showSplitPane}
+              selected={showSplitPane && selectedCandidate?.chembl_id === candidate.chembl_id}
               onClick={handleCardClick}
             />
           ))}
@@ -200,8 +204,8 @@ export function DrugCandidatesView() {
         )}
       </div>
 
-      {/* Detail panel */}
-      {selectedCandidate && (
+      {/* Desktop: inline detail panel */}
+      {showSplitPane && selectedCandidate && (
         <div className="flex-1 min-w-0 h-[calc(100vh-12rem)]">
           <CandidateDetailPanel
             key={selectedCandidate.chembl_id}
@@ -211,6 +215,17 @@ export function DrugCandidatesView() {
             onClose={handleClose}
           />
         </div>
+      )}
+
+      {/* Mobile: drawer overlay */}
+      {isMobile && (
+        <CandidateDetailDrawer
+          candidate={selectedCandidate}
+          routeData={routeData}
+          indicationFrequency={indicationFrequency}
+          open={hasSelection}
+          onOpenChange={(open) => { if (!open) handleClose(); }}
+        />
       )}
     </div>
   );

--- a/frontend-demo/src/components/layout/AppHeader.tsx
+++ b/frontend-demo/src/components/layout/AppHeader.tsx
@@ -1,12 +1,12 @@
 export function AppHeader() {
   return (
-    <header className="border-b border-border bg-card px-6 py-4">
-      <div className="max-w-7xl mx-auto flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold text-foreground tracking-tight">
+    <header className="border-b border-border bg-card px-4 sm:px-6 py-3 sm:py-4">
+      <div className="max-w-7xl mx-auto flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="text-lg sm:text-xl font-semibold text-foreground tracking-tight truncate">
             OSPF Ayurveda Knowledge Graph
           </h1>
-          <p className="text-sm text-muted-foreground">
+          <p className="text-xs sm:text-sm text-muted-foreground">
             Drug Discovery Analysis for Oral Mucositis
           </p>
         </div>

--- a/frontend-demo/src/components/markdown/MarkdownRenderer.tsx
+++ b/frontend-demo/src/components/markdown/MarkdownRenderer.tsx
@@ -35,21 +35,21 @@ const customComponents: Components = {
     </thead>
   ),
   th: ({ children }) => (
-    <th className="px-4 py-3 text-left font-semibold border-b border-border">
+    <th className="px-2 sm:px-4 py-2 sm:py-3 text-left font-semibold border-b border-border">
       {children}
     </th>
   ),
   td: ({ children }) => (
-    <td className="px-4 py-2.5 border-b border-border/50">{children}</td>
+    <td className="px-2 sm:px-4 py-2 sm:py-2.5 border-b border-border/50">{children}</td>
   ),
   tr: ({ children }) => <tr className="hover:bg-muted/30 transition-colors">{children}</tr>,
   h1: ({ children }) => (
-    <h1 className="text-2xl font-bold text-foreground mt-8 mb-4 pb-2 border-b-2 border-primary/30">
+    <h1 className="text-xl sm:text-2xl font-bold text-foreground mt-6 sm:mt-8 mb-3 sm:mb-4 pb-2 border-b-2 border-primary/30">
       {children}
     </h1>
   ),
   h2: ({ children }) => (
-    <h2 className="text-xl font-semibold text-foreground mt-8 mb-3 pb-1 border-b border-border">
+    <h2 className="text-lg sm:text-xl font-semibold text-foreground mt-6 sm:mt-8 mb-2 sm:mb-3 pb-1 border-b border-border">
       {children}
     </h2>
   ),

--- a/frontend-demo/src/components/visualization/CompositeScoreChart.tsx
+++ b/frontend-demo/src/components/visualization/CompositeScoreChart.tsx
@@ -8,6 +8,7 @@ import {
   ResponsiveContainer,
   Cell,
 } from 'recharts';
+import { useIsMobile } from '@/hooks/use-media-query';
 
 interface CandidateScore {
   name: string;
@@ -33,25 +34,35 @@ const safetyColors: Record<string, string> = {
   RED: 'hsl(0, 72%, 51%)',
 };
 
+function truncateName(name: string, max: number): string {
+  return name.length > max ? name.slice(0, max - 1) + '…' : name;
+}
+
 export function CompositeScoreChart() {
+  const isMobile = useIsMobile();
+  const axisWidth = isMobile ? 90 : 125;
+  const leftMargin = isMobile ? 95 : 130;
+  const tickSize = isMobile ? 10 : 11;
+
   return (
-    <div className="bg-card border border-border rounded-lg p-4">
+    <div className="bg-card border border-border rounded-lg p-3 sm:p-4">
       <h3 className="text-sm font-semibold text-foreground mb-3">
         Consensus Drug Candidate Rankings
       </h3>
-      <ResponsiveContainer width="100%" height={320}>
+      <ResponsiveContainer width="100%" height={isMobile ? 280 : 320}>
         <BarChart
           data={CONSENSUS_CANDIDATES}
           layout="vertical"
-          margin={{ top: 5, right: 30, left: 130, bottom: 5 }}
+          margin={{ top: 5, right: isMobile ? 15 : 30, left: leftMargin, bottom: 5 }}
         >
           <CartesianGrid strokeDasharray="3 3" stroke="hsl(0, 0%, 90%)" />
-          <XAxis type="number" domain={[0, 100]} tick={{ fontSize: 11 }} />
+          <XAxis type="number" domain={[0, 100]} tick={{ fontSize: tickSize }} />
           <YAxis
             dataKey="name"
             type="category"
-            tick={{ fontSize: 11 }}
-            width={125}
+            tick={{ fontSize: tickSize }}
+            width={axisWidth}
+            tickFormatter={(name: string) => truncateName(name, isMobile ? 14 : 25)}
           />
           <Tooltip
             formatter={(value) => [`${value}/100`, 'Composite Score']}
@@ -69,7 +80,7 @@ export function CompositeScoreChart() {
           </Bar>
         </BarChart>
       </ResponsiveContainer>
-      <div className="flex gap-4 mt-2 text-xs text-muted-foreground justify-center">
+      <div className="flex flex-wrap gap-3 sm:gap-4 mt-2 text-xs text-muted-foreground justify-center">
         {Object.entries(safetyColors).map(([label, color]) => (
           <span key={label} className="flex items-center gap-1">
             <span

--- a/frontend-demo/src/components/visualization/DataTableViz.tsx
+++ b/frontend-demo/src/components/visualization/DataTableViz.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from 'recharts';
+import { useIsMobile } from '@/hooks/use-media-query';
 import type { TableData } from '@/types/analysis';
 
 interface DataTableVizProps {
@@ -20,6 +21,7 @@ interface DataTableVizProps {
 }
 
 export function DataTableViz({ table }: DataTableVizProps) {
+  const isMobile = useIsMobile();
   const hasChart = table.numericColumns.length > 0 && table.rows.length > 1;
   const entityCol = findEntityColumn(table);
 
@@ -60,17 +62,18 @@ export function DataTableViz({ table }: DataTableVizProps) {
           <BarChart
             data={chartData}
             layout={entityCol ? 'vertical' : 'horizontal'}
-            margin={{ top: 5, right: 20, left: entityCol ? 100 : 5, bottom: 5 }}
+            margin={{ top: 5, right: isMobile ? 10 : 20, left: entityCol ? (isMobile ? 70 : 100) : 5, bottom: 5 }}
           >
             <CartesianGrid strokeDasharray="3 3" stroke="hsl(0, 0%, 90%)" />
             {entityCol ? (
               <>
-                <XAxis type="number" tick={{ fontSize: 11 }} />
+                <XAxis type="number" tick={{ fontSize: isMobile ? 10 : 11 }} />
                 <YAxis
                   dataKey="name"
                   type="category"
-                  tick={{ fontSize: 11 }}
-                  width={95}
+                  tick={{ fontSize: isMobile ? 10 : 11 }}
+                  width={isMobile ? 65 : 95}
+                  tickFormatter={(name: string) => name.length > (isMobile ? 10 : 20) ? name.slice(0, isMobile ? 9 : 19) + '…' : name}
                 />
               </>
             ) : (

--- a/frontend-demo/src/hooks/use-media-query.ts
+++ b/frontend-demo/src/hooks/use-media-query.ts
@@ -1,0 +1,22 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      const mql = window.matchMedia(query);
+      mql.addEventListener('change', callback);
+      return () => mql.removeEventListener('change', callback);
+    },
+    [query],
+  );
+
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    () => false,
+  );
+}
+
+export function useIsMobile(): boolean {
+  return !useMediaQuery('(min-width: 768px)');
+}


### PR DESCRIPTION
## Summary
- Implements responsive mobile layout across the frontend prototype using Tailwind CSS breakpoints and a `useMediaQuery` hook
- Converts the drug candidates split-pane (sidebar + detail) into a full-width list with a sliding drawer overlay on mobile (<768px), using the existing but previously unwired `CandidateDetailDrawer` component
- Makes all charts (CompositeScoreChart, DataTableViz), cards, tables, headers, and markdown content adapt to narrow screens with reduced margins, flexible widths, tighter padding, and name truncation

## Test plan
- Open the app at `localhost:5173` and toggle Chrome DevTools device toolbar (Ctrl+Shift+M)
- At **375px width** (iPhone SE): verify the drug candidates list renders full-width without horizontal overflow, tapping a card opens the right-sliding drawer with full details, and closing the drawer returns to the list
- At **768px+ width** (tablet/desktop): verify the existing split-pane sidebar + detail panel still works as before
- Check the Consensus Drug Candidate Rankings chart on the Summary tab renders with truncated labels and visible bars at mobile width
- Check markdown analysis content has readable table cells and heading sizes at mobile width
- Resize the browser continuously from 320px to 1280px to verify no layout breakage at any intermediate width